### PR TITLE
fix the bugs that train_bias does not work

### DIFF
--- a/GIFt/modules/lora.py
+++ b/GIFt/modules/lora.py
@@ -232,7 +232,7 @@ class LoRAConv(LoRALinearLike):
                 '''
                 see comments in LoRALinearLike
                 '''
-                self.parent_module(x)+self.parent_module._conv_forward(
+                return self.parent_module(x)+self.parent_module._conv_forward(
                 self.lora_dropout(x), 
                 self.lora_weight(),
                 bias=None)

--- a/GIFt/utils/factories.py
+++ b/GIFt/utils/factories.py
@@ -259,7 +259,7 @@ def mc_cname_contains(target_classname:str):
                 return False
     return check_func
 
-def mc_cname_in_sequence(target_classnames:Sequence[str]):
+def mc_cname_contains_sequence(target_classnames:Sequence[str]):
     """
     Returns a check function that checks if the module class name contains one of the target_names.
 


### PR DESCRIPTION
1. The original `__call__` function in the `FineTuningStrategy` check module first, then check para. However, check para will set the parameters in the module like `weight`, and `bias` as untrainable. So it should check the para first, then check the module to avoid this problem.
2. The original line "find=False" in the `check_para` function will remain True for all other parameters when it is set to True, so it should be placed in the for loop. Besides, judge whether `len(self.para_caps) == 0` is unnecessary,  since all parameters will be set to False (if no parameter satisfies check_para) in the end. 
3. Fix some typos.